### PR TITLE
Use DESEGMENT_ONE_MORE_SEGMENT to improve packet reassembly

### DIFF
--- a/ca.lua
+++ b/ca.lua
@@ -393,7 +393,7 @@ end
 -- returns number of bytes consumed or a negative number giving
 -- the number of bytes needed to complete the message
 local function decode (buf, pkt, root)
-  if buf:len()<16 then return 0 end
+  if buf:len()<16 then return -DESEGMENT_ONE_MORE_SEGMENT end
     
   local cmd = buf(0,2)
   local msglen


### PR DESCRIPTION
In decode function, it returns 0 if CA message is less than 16 bytes. However this causes packet assembly failure when the header of CA message is separated by packet segmentation.

I attached a capture file in zip file. 

[packet_reassembly.zip](https://github.com/mdavidsaver/cashark/files/2627762/packet_reassembly.zip)

In this capture file, packets of frame 8 and 9  should be reassembled but reassembly is not worked because of separated CA message header.

To improve this, I fixed decode function to return negative DESEGMENT_ONE_MORE_SEGMENT if a length of CA message is less than 16 bytes. DESEGMENT_ONE_MORE_SEGMENT is used to indicate need more bytes to decode the full message but don't know exactly its size.